### PR TITLE
Making maxBuffer a parameter to prevent gulp from failing on "stdout …

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -103,7 +103,7 @@ gulp.task("05-Sync-Unicorn", function (callback) {
   var options = {};
   options.siteHostName = habitat.getSiteUrl();
   options.authenticationConfigFile = config.websiteRoot + "/App_config/Include/Unicorn/Unicorn.UI.config";
-
+  options.maxBuffer = 10000 * 1024;
   unicorn(function() { return callback() }, options);
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -103,7 +103,7 @@ gulp.task("05-Sync-Unicorn", function (callback) {
   var options = {};
   options.siteHostName = habitat.getSiteUrl();
   options.authenticationConfigFile = config.websiteRoot + "/App_config/Include/Unicorn/Unicorn.UI.config";
-  options.maxBuffer = 10000 * 1024;
+  options.maxBuffer = Infinity;
   unicorn(function() { return callback() }, options);
 });
 

--- a/scripts/unicorn.js
+++ b/scripts/unicorn.js
@@ -39,7 +39,7 @@ module.exports = function (callback, options) {
 
 
   var syncScript =__dirname + "/Unicorn/./Sync.ps1 -secret " + secret + " -url " + url;
-  var options = { cwd: __dirname + "/Unicorn/", maxBuffer: 1024 * 500 };
+  var options = { cwd: __dirname + "/Unicorn/", maxBuffer: options.maxBuffer };
   var process = exec("powershell -executionpolicy unrestricted \"" + syncScript + "\"", options, function (err, stdout, stderr) {
     if (err !== null) throw err;
     console.log(stdout);


### PR DESCRIPTION
…maxBuffer exceeded"

Problem occurred when a large output from unicorn was being returned to gulp. The default 1024 * 500 buffer isn't large enough.

Modified unicorn.js to support parameter supplied from gulpfile.js